### PR TITLE
Update dockerdoom with a TCP server for MacOS hosts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,11 @@ run     mkdir ~/.vnc
 run     x11vnc -storepasswd 1234 ~/.vnc/passwd
 
 # Setup doom
+# Flip the comments this clone step if you want to build your own tcp dockerdoom
+#run     git clone https://github.com/briancain/dockerdoom.git
 run     git clone https://github.com/GideonRed/dockerdoom.git
 run     wget http://distro.ibiblio.org/pub/linux/distributions/slitaz/sources/packages/d/doom1.wad
 run     cd /dockerdoom/trunk && ./configure && make && make install
 
-# Autostart firefox (might not be the best way to do it, but it does the trick)
+# Autostart doom (might not be the best way to do it, but it does the trick)
 run     bash -c 'echo "/usr/local/games/psdoom -warp E1M1" >> /root/.bashrc'

--- a/README.md
+++ b/README.md
@@ -27,6 +27,15 @@ Now run the downloaded docker binary:
 ./dockerdoomd
 ```
 
+Are you trying to run this on macOS? Use the following command line arguments to
+setup dockerdoomd with a tcp server instead of a unix socket. Also make sure
+you're using the docker image `briancain/dockerdoomtcp` so they can talk to each
+other.
+
+```bash
+./dockerdoomd -imageName briancain/dockerdoomtcp -tcp
+```
+
 You should receive output similar to:
 
 ```
@@ -130,6 +139,7 @@ Containers and streaming technology (naively VNC) gives one possible solution to
 ## Links
 
 * [Github repo for the DOOM used here](https://github.com/GideonRed/dockerdoom)
+* [Github repo for the TCP DOOM used here](https://github.com/briancain/dockerdoom)
 * [Github repo for `dockerdoomd`](https://github.com/GideonRed/dockerdoomd)
 
 ## Thanks


### PR DESCRIPTION
This commit updates the dockerdoomd project with a couple of features:

- TCP server for MacOS hosts (used through flags)
- Cleans up unix socket file on shut down when receiving a SIGINT


__Note:__ I didn't add any way to override where the TCP server listens because at the moment it's pretty much hard coded in the dockerdoom source.